### PR TITLE
Add more CI entries to dockerignore

### DIFF
--- a/templates/dockerignore.tt
+++ b/templates/dockerignore.tt
@@ -8,8 +8,10 @@ docker-compose*.yml
 # CI/CD
 .github/
 .cache/
+.circleci/
 coverage/
 spec/
+test/
 features/
 .gitlab-ci.yml
 .travis.yml


### PR DESCRIPTION
A couple common directories to ignore:

- `.circleci/` for Circle CI's `.circleci/config.yml`
- `test/` for Rails apps that use the default TestUnit framework (instead of RSpec)