### PR TITLE
Support gems from git repoistory

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: .
   specs:
-    boxing (0.3.1)
+    boxing (0.4.0)
       bundler (~> 2.0)
       thor (~> 1.0)
 

--- a/README.md
+++ b/README.md
@@ -93,6 +93,7 @@ bundle exec boxing update
 * [ ] Package Database
   * [x] Built-in (Move to standalone repoistory in future)
   * [x] Standalone Repoistory
+  * [x] Support gems from `git` repoistory
   * [x] Customize Source
   * [ ] Base Image
     * [x] Alpine

--- a/lib/boxing/context.rb
+++ b/lib/boxing/context.rb
@@ -47,6 +47,7 @@ module Boxing
     #
     # @since 0.4.0
     def git?
+      pp @dependencies
       @dependencies.any?(&:git)
     end
 

--- a/lib/boxing/context.rb
+++ b/lib/boxing/context.rb
@@ -20,11 +20,14 @@ module Boxing
     #
     # @since 0.1.0
     def packages
-      @packages ||= Set.new(
-        @dependencies
-        .map(&:name)
-        .flat_map { |name| @database.package_for(name).to_a }
-      )
+      @packages ||=
+        Set
+        .new(default_packages)
+        .merge(
+          @dependencies
+          .map(&:name)
+          .flat_map { |name| @database.package_for(name).to_a }
+        )
     end
 
     # Check rubygems exists
@@ -36,6 +39,28 @@ module Boxing
     # @since 0.1.0
     def has?(*names)
       @dependencies.any? { |dep| names.include?(dep.name) }
+    end
+
+    # Does any gem from git
+    #
+    # @return [TrueClass|FalseClass]
+    #
+    # @since 0.4.0
+    def git?
+      @dependencies.any?(&:git)
+    end
+
+    # Default packages
+    #
+    # @return [Array<Boxing::Package>]
+    #
+    # @since 0.4.0
+    def default_packages
+      [
+        Package.new('build-base', mode: Package::BUILD)
+      ]
+        .push(git? ? Package.new('git', mode: Package::BUILD) : nil)
+        .compact
     end
 
     # Convert to binding

--- a/lib/boxing/version.rb
+++ b/lib/boxing/version.rb
@@ -1,5 +1,5 @@
 # frozen_string_literal: true
 
 module Boxing
-  VERSION = '0.3.1'
+  VERSION = '0.4.0'
 end

--- a/spec/boxing/context_spec.rb
+++ b/spec/boxing/context_spec.rb
@@ -8,10 +8,10 @@ RSpec.describe Boxing::Context do
   describe '#packages' do
     subject { context.packages }
 
-    it { is_expected.to be_empty }
+    it { is_expected.to include(Boxing::Package.new('build-base')) }
 
-    context '#when package exists' do
-      let(:context) { described_class.new(database, [instance_double('Bundler::Dependency', name: 'rails')]) }
+    context '#when extra package exists' do
+      let(:context) { described_class.new(database, [instance_double('Bundler::Dependency', name: 'rails', git: nil)]) }
 
       before do
         allow(database).to receive(:package_for).with('rails').and_return([Boxing::Package.new('tzdata')])
@@ -21,13 +21,40 @@ RSpec.describe Boxing::Context do
     end
   end
 
+  describe '#default_packages' do
+    subject { context.default_packages }
+
+    it { is_expected.to include(Boxing::Package.new('build-base')) }
+    it { is_expected.not_to include(Boxing::Package.new('git')) }
+
+    context '#when git source exists' do
+      let(:context) do
+        described_class.new(database, [instance_double('Bundler::Dependency', name: 'rails', git: true)])
+      end
+
+      it { is_expected.to include(Boxing::Package.new('git')) }
+    end
+  end
+
+  describe '#git?' do
+    it { is_expected.not_to be_git }
+
+    context '#when git source exists' do
+      subject do
+        described_class.new(database, [instance_double('Bundler::Dependency', name: 'rails', git: true)])
+      end
+
+      it { is_expected.to be_git }
+    end
+  end
+
   describe '#has?' do
     subject { context.has?('rails') }
 
     it { is_expected.to be_falsy }
 
     context '#when gem exists' do
-      let(:context) { described_class.new(database, [instance_double('Bundler::Dependency', name: 'rails')]) }
+      let(:context) { described_class.new(database, [instance_double('Bundler::Dependency', name: 'rails', git: nil)]) }
 
       it { is_expected.to be_truthy }
     end

--- a/templates/Dockerfile.tt
+++ b/templates/Dockerfile.tt
@@ -4,7 +4,7 @@ ARG RUBY_VERSION=<%= RUBY_VERSION %>
 FROM ruby:${RUBY_VERSION}-alpine AS gem
 ARG APP_ROOT
 
-RUN apk add --no-cache build-base <%= packages.select(&:build?).join(' ') %>
+RUN apk add --no-cache <%= packages.select(&:build?).join(' ') %>
 
 RUN mkdir -p ${APP_ROOT}
 COPY Gemfile Gemfile.lock ${APP_ROOT}/
@@ -29,9 +29,6 @@ ARG APP_ROOT
 <%- if packages.select(&:runtime?).any? -%>
 RUN apk add --no-cache <%= packages.select(&:runtime?).join(' ') %>
 
-ARG REVISION
-ENV REVISION $REVISION
-
 <%- end -%>
 COPY --from=gem /usr/local/bundle/config /usr/local/bundle/config
 COPY --from=gem /usr/local/bundle /usr/local/bundle
@@ -46,6 +43,9 @@ ENV RAILS_LOG_TO_STDOUT=true
 ENV APP_ROOT=$APP_ROOT
 
 COPY . ${APP_ROOT}
+
+ARG REVISION
+ENV REVISION $REVISION
 RUN echo $REVISION > ${SERVER_ROOT}/REVISION
 
 # Apply Execute Permission


### PR DESCRIPTION
According to issue #2, we need the `git` package for the project which uses `git` as a gem source.

```ruby
git_source(:github) { |repo| "https://github.com/#{repo}.git" }
# ...
gem "rails", github: "rails/rails", branch: "7-0-stable"
```