### PR TITLE
Allow to customize .dockerignore with config

### DIFF
--- a/README.md
+++ b/README.md
@@ -78,13 +78,25 @@ bundle exec boxing update
 
 > If the generated `Dockerfile` is not satisfy, please try to update it.
 
-### Configuration
+## Configuration
 
 If `config/boxing.rb` is found, it will be loaded and change the generated `Dockerfile` and `.dockerignore`
+
+### Source Code Root
 
 ```ruby
 Boxing.config do |c|
  c.root = '/var/www'
+end
+```
+
+### Ignore Files
+
+```ruby
+Boxing.config do |c|
+ c.ignores = %w[
+   vendor/gems
+ ]
 end
 ```
 
@@ -93,10 +105,10 @@ end
 * [x] `Dockerfile` generator
 * [x] `.dockerignore` generator
   * [x] Common ignore files
-  * [ ] Customizable ignore files
+  * [x] Customizable ignore files
 * [ ] Docker Compose generator
   * [ ] Production Version
-  * [ ] Development Version
+  * [x] Development Version
 * [x] Customize config file `config/boxing.rb`
   * [x] Customize `APP_ROOT`
   * [ ] Extra packages

--- a/lib/boxing/config.rb
+++ b/lib/boxing/config.rb
@@ -9,7 +9,7 @@ module Boxing
     #   @return [String] the application root
     #
     # @since 0.5.0
-    attr_accessor :root, :name, :registry
+    attr_accessor :root, :name, :registry, :ignores
 
     # @since 0.5.0
     def initialize(&block)

--- a/templates/dockerignore.tt
+++ b/templates/dockerignore.tt
@@ -36,3 +36,8 @@ tmp/*
 
 # Boxing
 config/boxing.rb
+<% if config.ignores -%>
+
+# Customize Ignores
+<%= Array[config.ignores].join("\n") %>
+<%- end -%>


### PR DESCRIPTION
New config supported.

```ruby
Boxing.config do |c|
 c.ignores = %w[
   vendor/gems
 ]
end
```