### PR TITLE
Allow to assets precompile when build

### DIFF
--- a/README.md
+++ b/README.md
@@ -100,6 +100,18 @@ Boxing.config do |c|
 end
 ```
 
+### Assets Precompile
+
+This feature is disabled by default and suggest to use CI to build it.
+
+```ruby
+Boxing.config do |c|
+ c.assets_precompile = true
+ # If not given the `node -v` will be execute
+ c.node_version = '14.18'
+end
+```
+
 ### Health Check
 
 ```ruby
@@ -120,6 +132,8 @@ end
 * [ ] Docker Compose generator
   * [ ] Production Version
   * [x] Development Version
+* [x] Allow run Assets Precompile in Container
+  * [ ] Disable `RAILS_SERVE_STATIC_FILES` by default
 * [x] Customize config file `config/boxing.rb`
   * [x] Customize `APP_ROOT`
   * [ ] Extra packages
@@ -127,7 +141,7 @@ end
     * [ ] Build Stage
     * [ ] Entrypoint
     * [ ] Command
-    * [ ] Expose Port
+    * [x] Expose Port
 * [x] Health Check
   * [x] [Liveness](https://github.com/elct9620/openbox) gem detection
   * [x] Add `curl` for web application

--- a/lib/boxing/config.rb
+++ b/lib/boxing/config.rb
@@ -9,7 +9,9 @@ module Boxing
     #   @return [String] the application root
     #
     # @since 0.5.0
-    attr_accessor :root, :name, :registry, :ignores, :port, :health_check, :health_check_path
+    attr_accessor :root, :name, :registry, :ignores, :port,
+                  :health_check, :health_check_path,
+                  :assets_precompile, :node_version
 
     # @since 0.5.0
     def initialize(&block)
@@ -17,6 +19,7 @@ module Boxing
       @root = '/srv/app'
       @port = 9292
       @health_path = '/status'
+      @assets_precompile = false
 
       instance_exec(self, &block) if defined?(yield)
     end

--- a/lib/boxing/context.rb
+++ b/lib/boxing/context.rb
@@ -71,6 +71,17 @@ module Boxing
         .compact
     end
 
+    # Return node.js version
+    #
+    # @return [String]
+    #
+    # @since 0.6.0
+    def node_version
+      return config.node_version if config.node_version
+
+      `node -v`.gsub(/^v/, '')
+    end
+
     # Convert to binding
     #
     # @return [Binding]

--- a/templates/Dockerfile.tt
+++ b/templates/Dockerfile.tt
@@ -1,5 +1,6 @@
 ARG APP_ROOT=<%= config.root %>
 ARG RUBY_VERSION=<%= RUBY_VERSION %>
+<%- if config.assets_precompile -%>ARG NODE_VERSION=<%= node_version %><%- end -%>
 
 FROM ruby:${RUBY_VERSION}-alpine AS gem
 ARG APP_ROOT
@@ -23,6 +24,29 @@ RUN gem install bundler:<%= Bundler::VERSION %> \
     && find /usr/local/bundle -type f -name '*.o' -delete \
     && rm -rf /usr/local/bundle/cache/*.gem
 
+<%- if config.assets_precompile -%>
+FROM node:${NODE_VERSION}-alpine as node
+FROM ruby:${RUBY_VERSION}-alpine as assets
+ARG APP_ROOT
+
+<%- if packages.select(&:runtime?).any? -%>
+RUN apk add --no-cache <%= packages.select(&:runtime?).join(' ') %> yarn
+
+<%- end -%>
+COPY --from=node /usr/local/bin/node /usr/local/bin/node
+
+COPY --from=gem /usr/local/bundle/config /usr/local/bundle/config
+COPY --from=gem /usr/local/bundle /usr/local/bundle
+COPY --from=gem /${APP_ROOT}/vendor/bundle /${APP_ROOT}/vendor/bundle
+
+RUN mkdir -p ${APP_ROOT}
+COPY . ${APP_ROOT}
+
+ENV RAILS_ENV production
+WORKDIR ${APP_ROOT}
+RUN bundle exec rake assets:precompile
+
+<%- end -%>
 FROM ruby:${RUBY_VERSION}-alpine
 ARG APP_ROOT
 
@@ -39,10 +63,12 @@ RUN mkdir -p ${APP_ROOT}
 <%- if has?('rails') -%>
 ENV RAILS_ENV=production
 ENV RAILS_LOG_TO_STDOUT=true
+ENV RAILS_SERVE_STATIC_FILES=yes
 <%- end -%>
 ENV APP_ROOT=$APP_ROOT
 
 COPY . ${APP_ROOT}
+COPY --from=assets /${APP_ROOT}/public /${APP_ROOT}/public
 
 ARG REVISION
 ENV REVISION $REVISION
@@ -59,7 +85,6 @@ RUN adduser -h ${APP_ROOT} -D -s /bin/nologin ruby ruby && \
 
 USER ruby
 WORKDIR ${APP_ROOT}
-
 
 EXPOSE <%= config.port %>
 <%- if has?('liveness') || config.health_check -%>


### PR DESCRIPTION
Add `config.assets_precompile = true` to run assets precompile in docker build instead of CI.