### PR TITLE
Fix assets precompile stage missing Rails master key

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: .
   specs:
-    boxing (0.7.0)
+    boxing (0.7.1)
       bundler (~> 2.0)
       thor (~> 1.0)
 

--- a/README.md
+++ b/README.md
@@ -121,6 +121,8 @@ Boxing.config do |c|
 end
 ```
 
+> When building the image, you have to add `--build-arg RAILS_MASTER_KEY=...` to set your production key to compile it correctly.
+
 ### Health Check
 
 ```ruby

--- a/lib/boxing/version.rb
+++ b/lib/boxing/version.rb
@@ -1,5 +1,5 @@
 # frozen_string_literal: true
 
 module Boxing
-  VERSION = '0.7.0'
+  VERSION = '0.7.1'
 end

--- a/templates/Dockerfile.tt
+++ b/templates/Dockerfile.tt
@@ -26,6 +26,9 @@ RUN gem install bundler:<%= Bundler::VERSION %> \
 FROM node:${NODE_VERSION}-alpine as node
 FROM ruby:${RUBY_VERSION}-alpine as assets
 ARG APP_ROOT
+ARG RAILS_MASTER_KEY
+
+ENV RAILS_MASTER_KEY $RAILS_MASTER_KEY
 
 <%- if packages.select(&:runtime?).any? -%>
 RUN apk add --no-cache <%= packages.select(&:runtime?).join(' ') %> yarn


### PR DESCRIPTION
When assets precompile, we may need `RAILS_MASTER_KEY` for it, this PR adds the build argument options to inject it into the assets precompile stage.